### PR TITLE
Add an option to remove exited container

### DIFF
--- a/localstack_utils/container.py
+++ b/localstack_utils/container.py
@@ -31,6 +31,7 @@ class Container:
         environment_variables: dict = None,
         bind_ports: dict = None,
         pro: bool = False,
+        auto_remove: bool = False,
     ):
         environment_variables = environment_variables or {}
         environment_variables["GATEWAY_LISTEN"] = gateway_listen
@@ -56,6 +57,7 @@ class Container:
             image_name_or_default,
             ports=bind_ports,
             environment=environment_variables,
+            auto_remove=auto_remove,
             detach=True,
         )
 

--- a/localstack_utils/localstack.py
+++ b/localstack_utils/localstack.py
@@ -48,6 +48,7 @@ class Localstack:
                 docker_configuration.environment_variables,
                 docker_configuration.port_mappings,
                 docker_configuration.pro,
+                docker_configuration.auto_remove_container,
             )
 
             self.setup_logger()
@@ -77,6 +78,7 @@ def startup_localstack(
     env_variables=None,
     gateway_listen="",
     ignore_docker_errors=False,
+    auto_remove_container=False,
 ):
     global localstack_instance
     localstack_instance = Localstack.INSTANCE()
@@ -100,6 +102,9 @@ def startup_localstack(
 
     if gateway_listen:
         config.gateway_listen = gateway_listen
+
+    if auto_remove_container:
+        config.auto_remove_container = auto_remove_container
 
     localstack_instance.startup(config)
 

--- a/localstack_utils/localstack_docker_configuration.py
+++ b/localstack_utils/localstack_docker_configuration.py
@@ -14,3 +14,4 @@ class LocalstackDockerConfiguration:
     use_dingle_docker_container = False
     ignore_docker_runerrors = False
     pro = False
+    auto_remove_container = False


### PR DESCRIPTION
Hi pinzon,

I'm Tatsuya Kato, and I've been using your library for testing purposes. Thanks a lot for the work you've put into it—it's been super helpful for my projects.

While running my tests, I noticed that the stopped containers were lingering after each test execution.
To address this, I added an `auto_remove_container` option. 
Thanks for considering my PR!

